### PR TITLE
Add additional roles and permissions needed to provision Domain Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ future changes by simply running `terraform apply
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws_region | The AWS region where the non-global resources for the User Services account are to be provisioned (e.g. "us-east-1"). | `string` | `us-east-1` | no |
+| executedomainmanagerecs_role_description | The description to associate with the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager ECS in the User Services account. | `string` | `Allows sufficient permissions needed for Domain Manager ECS execution in the User Services account.` | no |
+| executedomainmanagerecs_role_name | The name to assign the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager ECS in the User Services account. | `string` | `ExecuteDomainManagerECS` | no |
+| executedomainmanagerecstask_role_description | The description to associate with the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager ECS tasks in the User Services account. | `string` | `Allows sufficient permissions needed for Domain Manager ECS task execution in the User Services account.` | no |
+| executedomainmanagerecstask_role_name | The name to assign the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager ECS tasks in the User Services account. | `string` | `ExecuteDomainManagerECSTask` | no |
+| executedomainmanagerlambda_role_description | The description to associate with the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager Lambdas in the User Services account. | `string` | `Allows sufficient permissions needed for Domain Manager Lambda execution in the User Services account.` | no |
+| executedomainmanagerlambda_role_name | The name to assign the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager Lambdas in the User Services account. | `string` | `ExecuteDomainManagerLambda` | no |
 | provisionaccount_role_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the User Services account. | `string` | `Allows sufficient permissions to provision all AWS resources in the User Services account.` | no |
 | provisionaccount_role_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the User Services account. | `string` | `ProvisionAccount` | no |
 | provisiondomainmanager_role_description | The description to associate with the IAM policy and role that allows sufficient permissions to provision all AWS resources needed for Domain Manager in the User Services account. | `string` | `Allows sufficient permissions to provision all AWS resources needed for Domain Manager in the User Services account.` | no |
@@ -100,6 +106,9 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
+| executedomainmanagerecs_role | The IAM role that allows sufficient permissions to execute Domain Manager ECS in the User Services account. |
+| executedomainmanagerecstask_role | The IAM role that allows sufficient permissions to execute Domain Manager ECS tasks in the User Services account. |
+| executedomainmanagerlambda_role | The IAM role that allows sufficient permissions to execute Domain Manager Lambdas in the User Services account. |
 | provisionaccount_role | The IAM role that allows sufficient permissions to provision all AWS resources in the User Services account. |
 | provisiondomainmanager_role | The IAM role that allows sufficient permissions to provision all AWS resources for Domain Manager in the User Services account. |
 

--- a/assume_role_policy_ecs_doc.tf
+++ b/assume_role_policy_ecs_doc.tf
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------------------
+# Create an IAM policy document that allows ECS to assume this role.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assume_role_ecs" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "ecs-tasks.amazonaws.com",
+      ]
+    }
+  }
+}

--- a/assume_role_policy_lambda_doc.tf
+++ b/assume_role_policy_lambda_doc.tf
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------------------
+# Create an IAM policy document that allows Lambdas to assume this role.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assume_role_lambda" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "lambda.amazonaws.com",
+      ]
+    }
+  }
+}

--- a/executedomainmanagerecs_policy.tf
+++ b/executedomainmanagerecs_policy.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "executedomainmanagerecs" {
     ]
 
     resources = [
-      "arn:aws:ssm::${local.userservices_account_id}:parameter/domain-manager/*",
+      "arn:aws:ssm:*:${local.userservices_account_id}:parameter/domain-manager/*",
     ]
   }
 }

--- a/executedomainmanagerecs_policy.tf
+++ b/executedomainmanagerecs_policy.tf
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows sufficient AWS permissions to execute
+# Domain Manager ECS in the User Services account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "executedomainmanagerecs" {
+  statement {
+    actions = [
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      "arn:aws:ssm::${local.userservices_account_id}:parameter/domain-manager/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "executedomainmanagerecs" {
+  description = var.executedomainmanagerecs_role_description
+  name        = var.executedomainmanagerecs_role_name
+  policy      = data.aws_iam_policy_document.executedomainmanagerecs.json
+}

--- a/executedomainmanagerecs_policy_attachment.tf
+++ b/executedomainmanagerecs_policy_attachment.tf
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------------------
+# Attach the policies that allow sufficient AWS permissions to execute Domain
+# Manager ECS in the User Services account to the appropriate role.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "executedomainmanagerecs" {
+  policy_arn = aws_iam_policy.executedomainmanagerecs.arn
+  role       = aws_iam_role.executedomainmanagerecs.name
+}
+
+resource "aws_iam_role_policy_attachment" "aws_ecs_task_execution_role" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  role       = aws_iam_role.executedomainmanagerecs.name
+}

--- a/executedomainmanagerecs_role.tf
+++ b/executedomainmanagerecs_role.tf
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows sufficient AWS permissions to execute
+# Domain Manager ECS in the User Services account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "executedomainmanagerecs" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_ecs.json
+  description        = var.executedomainmanagerecs_role_description
+  name               = var.executedomainmanagerecs_role_name
+  tags               = var.tags
+}

--- a/executedomainmanagerecstask_policy.tf
+++ b/executedomainmanagerecstask_policy.tf
@@ -1,0 +1,147 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows sufficient AWS permissions to execute
+# Domain Manager ECS tasks in the User Services account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "executedomainmanagerecstask" {
+  statement {
+    actions = [
+      "acm:DeleteCertificate",
+      "acm:GetCertificate",
+      "acm:ListTagsForCertificate",
+      "acm:RemoveTagsFromCertificate",
+      "acm:UpdateCertificateOptions",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/app"
+      values   = ["domain-manager"]
+    }
+  }
+
+  statement {
+    actions = [
+      "acm:AddTagsToCertificate",
+      "acm:DescribeCertificate",
+      "acm:ListCertificates",
+      "acm:RequestCertificate",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "cloudfront:DeleteDistribution",
+      "cloudfront:GetDistribution",
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource",
+      "cloudfront:UpdateDistribution"
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/app"
+      values   = ["domain-manager"]
+    }
+  }
+
+  statement {
+    actions = [
+      "cloudfront:CreateDistribution",
+      "cloudfront:CreateDistributionWithTags",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/app"
+      values   = ["domain-manager"]
+    }
+  }
+
+  statement {
+    actions = [
+      "cognito-idp:AdminAddUserToGroup",
+      "cognito-idp:AdminConfirmSignUp",
+      "cognito-idp:AdminCreateUser",
+      "cognito-idp:AdminDeleteUser",
+      "cognito-idp:AdminDisableUser",
+      "cognito-idp:AdminEnableUser",
+      "cognito-idp:AdminGetUser",
+      "cognito-idp:AdminInitiateAuth",
+      "cognito-idp:AdminListDevices",
+      "cognito-idp:AdminListGroupsForUser",
+      "cognito-idp:AdminRemoveUserFromGroup",
+      "cognito-idp:AdminResetUserPassword",
+      "cognito-idp:SignUp",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/app"
+      values   = ["domain-manager"]
+    }
+  }
+
+  statement {
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:ChangeTagsForResource",
+      "route53:CreateHostedZone",
+      "route53:DeleteHostedZone",
+      "route53:GetHostedZone",
+      "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
+      "route53:ListTagsForResource"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:DeleteBucketPolicy",
+      "s3:DeleteBucketWebsite",
+      "s3:DeleteObject",
+      "s3:GetBucketWebsite",
+      "s3:GetObject",
+      "s3:ListAllMyBuckets",
+      "s3:ListBucket",
+      "s3:PutBucketPolicy",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:PutBucketWebsite",
+      "s3:PutObject"
+    ]
+
+    resources = ["*"]
+  }
+
+
+  statement {
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      "arn:aws:sqs::${local.userservices_account_id}:domain-manager-*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "executedomainmanagerecstask" {
+  description = var.executedomainmanagerecstask_role_description
+  name        = var.executedomainmanagerecstask_role_name
+  policy      = data.aws_iam_policy_document.executedomainmanagerecstask.json
+}

--- a/executedomainmanagerecstask_policy.tf
+++ b/executedomainmanagerecstask_policy.tf
@@ -38,7 +38,6 @@ data "aws_iam_policy_document" "executedomainmanagerecstask" {
       "cloudfront:DeleteDistribution",
       "cloudfront:GetDistribution",
       "cloudfront:GetDistributionConfig",
-      "cloudfront:TagResource",
       "cloudfront:UntagResource",
       "cloudfront:UpdateDistribution"
     ]
@@ -56,15 +55,12 @@ data "aws_iam_policy_document" "executedomainmanagerecstask" {
     actions = [
       "cloudfront:CreateDistribution",
       "cloudfront:CreateDistributionWithTags",
+      "cloudfront:ListDistributions",
+      "cloudfront:ListTagsForResource",
+      "cloudfront:TagResource",
     ]
 
     resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:RequestTag/app"
-      values   = ["domain-manager"]
-    }
   }
 
   statement {

--- a/executedomainmanagerecstask_policy.tf
+++ b/executedomainmanagerecstask_policy.tf
@@ -123,6 +123,7 @@ data "aws_iam_policy_document" "executedomainmanagerecstask" {
       "s3:ListBucket",
       "s3:PutBucketPolicy",
       "s3:PutBucketPublicAccessBlock",
+      "s3:PutBucketTagging",
       "s3:PutBucketWebsite",
       "s3:PutObject"
     ]

--- a/executedomainmanagerecstask_policy.tf
+++ b/executedomainmanagerecstask_policy.tf
@@ -81,6 +81,8 @@ data "aws_iam_policy_document" "executedomainmanagerecstask" {
       "cognito-idp:AdminListGroupsForUser",
       "cognito-idp:AdminRemoveUserFromGroup",
       "cognito-idp:AdminResetUserPassword",
+      "cognito-idp:ListUsers",
+      "cognito-idp:ListUsersInGroup",
       "cognito-idp:SignUp",
     ]
 

--- a/executedomainmanagerecstask_policy.tf
+++ b/executedomainmanagerecstask_policy.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "executedomainmanagerecstask" {
     ]
 
     resources = [
-      "arn:aws:sqs::${local.userservices_account_id}:domain-manager-*",
+      "arn:aws:sqs:*:${local.userservices_account_id}:domain-manager-*",
     ]
   }
 }

--- a/executedomainmanagerecstask_policy_attachment.tf
+++ b/executedomainmanagerecstask_policy_attachment.tf
@@ -1,0 +1,9 @@
+# ------------------------------------------------------------------------------
+# Attach the policy that allows sufficient AWS permissions to execute Domain
+# Manager ECS tasks in the User Services account to the appropriate role.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "executedomainmanagerecstask" {
+  policy_arn = aws_iam_policy.executedomainmanagerecstask.arn
+  role       = aws_iam_role.executedomainmanagerecstask.name
+}

--- a/executedomainmanagerecstask_role.tf
+++ b/executedomainmanagerecstask_role.tf
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows sufficient AWS permissions to execute
+# Domain Manager ECS tasks in the User Services account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "executedomainmanagerecstask" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_ecs.json
+  description        = var.executedomainmanagerecstask_role_description
+  name               = var.executedomainmanagerecstask_role_name
+  tags               = var.tags
+}

--- a/executedomainmanagerlambda_policy.tf
+++ b/executedomainmanagerlambda_policy.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "executedomainmanagerlambda" {
     ]
 
     resources = [
-      "arn:aws:sqs::${local.userservices_account_id}:domain-manager-*",
+      "arn:aws:sqs:*:${local.userservices_account_id}:domain-manager-*",
     ]
   }
 }

--- a/executedomainmanagerlambda_policy.tf
+++ b/executedomainmanagerlambda_policy.tf
@@ -1,0 +1,53 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows sufficient AWS permissions to execute
+# Domain Manager Lambdas in the User Services account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "executedomainmanagerlambda" {
+  statement {
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+    ]
+
+    resources = [
+      "arn:aws:logs:::*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "arn:aws:logs:::log-group:/aws/lambda/*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "sqs:SendMessage",
+    ]
+
+    resources = [
+      "arn:aws:sqs::${local.userservices_account_id}:domain-manager-*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "executedomainmanagerlambda" {
+  description = var.executedomainmanagerlambda_role_description
+  name        = var.executedomainmanagerlambda_role_name
+  policy      = data.aws_iam_policy_document.executedomainmanagerlambda.json
+}

--- a/executedomainmanagerlambda_policy_attachment.tf
+++ b/executedomainmanagerlambda_policy_attachment.tf
@@ -1,0 +1,9 @@
+# ------------------------------------------------------------------------------
+# Attach the policy that allows sufficient AWS permissions to execute Domain
+# Manager Lambdas in the User Services account to the appropriate role.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "executedomainmanagerlambda" {
+  policy_arn = aws_iam_policy.executedomainmanagerlambda.arn
+  role       = aws_iam_role.executedomainmanagerlambda.name
+}

--- a/executedomainmanagerlambda_role.tf
+++ b/executedomainmanagerlambda_role.tf
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows sufficient AWS permissions to execute
+# Domain Manager Lambdas in the User Services account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "executedomainmanagerlambda" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_lambda.json
+  description        = var.executedomainmanagerlambda_role_description
+  name               = var.executedomainmanagerlambda_role_name
+  tags               = var.tags
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,18 @@
+output "executedomainmanagerecs_role" {
+  value       = aws_iam_role.executedomainmanagerecs
+  description = "The IAM role that allows sufficient permissions to execute Domain Manager ECS in the User Services account."
+}
+
+output "executedomainmanagerecstask_role" {
+  value       = aws_iam_role.executedomainmanagerecstask
+  description = "The IAM role that allows sufficient permissions to execute Domain Manager ECS tasks in the User Services account."
+}
+
+output "executedomainmanagerlambda_role" {
+  value       = aws_iam_role.executedomainmanagerlambda
+  description = "The IAM role that allows sufficient permissions to execute Domain Manager Lambdas in the User Services account."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the User Services account."

--- a/provisiondomainmanager_policy.tf
+++ b/provisiondomainmanager_policy.tf
@@ -120,7 +120,7 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_ecr_ecs_elb_events
     ]
 
     resources = [
-      "arn:aws:ecr::${local.userservices_account_id}:repository/domain-manager-*",
+      "arn:aws:ecr:*:${local.userservices_account_id}:repository/domain-manager-*",
     ]
   }
 
@@ -160,10 +160,10 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_ecr_ecs_elb_events
     ]
 
     resources = [
-      "arn:aws:ecs::${local.userservices_account_id}:cluster/domain-manager-*",
-      "arn:aws:ecs::${local.userservices_account_id}:service/domain-manager-*",
-      "arn:aws:ecs::${local.userservices_account_id}:task/domain-manager-*",
-      "arn:aws:ecs::${local.userservices_account_id}:task-definition/domain-manager-*",
+      "arn:aws:ecs:*:${local.userservices_account_id}:cluster/domain-manager-*",
+      "arn:aws:ecs:*:${local.userservices_account_id}:service/domain-manager-*",
+      "arn:aws:ecs:*:${local.userservices_account_id}:task/domain-manager-*",
+      "arn:aws:ecs:*:${local.userservices_account_id}:task-definition/domain-manager-*",
     ]
   }
 
@@ -198,10 +198,10 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_ecr_ecs_elb_events
     ]
 
     resources = [
-      "arn:aws:elasticloadbalancing::${local.userservices_account_id}:listener/*/domain-manager-*",
-      "arn:aws:elasticloadbalancing::${local.userservices_account_id}:listener-rule/*/domain-manager-*",
-      "arn:aws:elasticloadbalancing::${local.userservices_account_id}:loadbalancer/*/domain-manager-*",
-      "arn:aws:elasticloadbalancing::${local.userservices_account_id}:targetgroup/domain-manager-*",
+      "arn:aws:elasticloadbalancing:*:${local.userservices_account_id}:listener/*/domain-manager-*",
+      "arn:aws:elasticloadbalancing:*:${local.userservices_account_id}:listener-rule/*/domain-manager-*",
+      "arn:aws:elasticloadbalancing:*:${local.userservices_account_id}:loadbalancer/*/domain-manager-*",
+      "arn:aws:elasticloadbalancing:*:${local.userservices_account_id}:targetgroup/domain-manager-*",
     ]
   }
 
@@ -310,8 +310,8 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_lambda_logs_rds_do
     ]
 
     resources = [
-      "arn:aws:lambda::${local.userservices_account_id}:layer:domain-manager-*",
-      "arn:aws:lambda::${local.userservices_account_id}:function:domain-manager-*",
+      "arn:aws:lambda:*:${local.userservices_account_id}:layer:domain-manager-*",
+      "arn:aws:lambda:*:${local.userservices_account_id}:function:domain-manager-*",
     ]
   }
 
@@ -341,7 +341,7 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_lambda_logs_rds_do
     ]
 
     resources = [
-      "arn:aws:logs::${local.userservices_account_id}:log-group:domain-manager-*:*",
+      "arn:aws:logs:*:${local.userservices_account_id}:log-group:domain-manager-*:*",
     ]
   }
 
@@ -427,12 +427,12 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_lambda_logs_rds_do
     ]
 
     resources = [
-      "arn:aws:rds::${local.userservices_account_id}:cluster:domain-manager-*",
-      "arn:aws:rds::${local.userservices_account_id}:cluster-pg:domain-manager-*",
-      "arn:aws:rds::${local.userservices_account_id}:cluster-snapshot:domain-manager-*",
-      "arn:aws:rds::${local.userservices_account_id}:db:domain-manager-*",
-      "arn:aws:rds::${local.userservices_account_id}:secgrp:domain-manager-*",
-      "arn:aws:rds::${local.userservices_account_id}:subgrp:domain-manager-*",
+      "arn:aws:rds:*:${local.userservices_account_id}:cluster:domain-manager-*",
+      "arn:aws:rds:*:${local.userservices_account_id}:cluster-pg:domain-manager-*",
+      "arn:aws:rds:*:${local.userservices_account_id}:cluster-snapshot:domain-manager-*",
+      "arn:aws:rds:*:${local.userservices_account_id}:db:domain-manager-*",
+      "arn:aws:rds:*:${local.userservices_account_id}:secgrp:domain-manager-*",
+      "arn:aws:rds:*:${local.userservices_account_id}:subgrp:domain-manager-*",
     ]
   }
 
@@ -554,7 +554,7 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_s3_sqs_ssm_doc" {
     ]
 
     resources = [
-      "arn:aws:ssm::${local.userservices_account_id}:parameter/domain-manager/*",
+      "arn:aws:ssm:*:${local.userservices_account_id}:parameter/domain-manager/*",
     ]
   }
 

--- a/provisiondomainmanager_policy.tf
+++ b/provisiondomainmanager_policy.tf
@@ -533,7 +533,7 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_s3_sqs_ssm_doc" {
     ]
 
     resources = [
-      "arn:aws:sqs::${local.userservices_account_id}:domain-manager-*",
+      "arn:aws:sqs:*:${local.userservices_account_id}:domain-manager-*",
     ]
   }
 

--- a/provisiondomainmanager_policy.tf
+++ b/provisiondomainmanager_policy.tf
@@ -3,7 +3,7 @@
 # all AWS resources for Domain Manager in the User Services account.
 # ------------------------------------------------------------------------------
 
-data "aws_iam_policy_document" "provisiondomainmanager_policy_acm_cognito_ec2_doc" {
+data "aws_iam_policy_document" "provisiondomainmanager_policy_acm_cloudwatch_cognito_ec2_doc" {
   statement {
     actions = [
       "acm:DeleteCertificate",
@@ -69,6 +69,9 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_acm_cognito_ec2_do
       "acm:DescribeCertificate",
       "acm:ListCertificates",
       "acm:RequestCertificate",
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
       "cognito-idp:CreateUserPool",
       "cognito-idp:DescribeUserPool",
       "cognito-idp:DescribeUserPoolClient",
@@ -97,10 +100,10 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_acm_cognito_ec2_do
   }
 }
 
-resource "aws_iam_policy" "provisiondomainmanager_policy_acm_cognito_ec2" {
-  description = "${var.provisiondomainmanager_role_description} (ACM, Cognito, EC2)"
-  name        = "${var.provisiondomainmanager_role_name}-acm-cognito-ec2"
-  policy      = data.aws_iam_policy_document.provisiondomainmanager_policy_acm_cognito_ec2_doc.json
+resource "aws_iam_policy" "provisiondomainmanager_policy_acm_cloudwatch_cognito_ec2" {
+  description = "${var.provisiondomainmanager_role_description} (ACM, CloudWatch, Cognito, EC2)"
+  name        = "${var.provisiondomainmanager_role_name}-acm-cloudwatch-cognito-ec2"
+  policy      = data.aws_iam_policy_document.provisiondomainmanager_policy_acm_cloudwatch_cognito_ec2_doc.json
 }
 
 data "aws_iam_policy_document" "provisiondomainmanager_policy_ecr_ecs_elb_events_doc" {
@@ -132,28 +135,10 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_ecr_ecs_elb_events
 
   statement {
     actions = [
-      "ecr:DescribeRegistry",
-      "ecr:DescribeRepositories",
-      "ecr:GetAuthorizationToken",
-      "ecr:ListTagsForResource",
-      "ecr:TagResource",
-      "ecr:UntagResource",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
       "ecs:CreateService",
       "ecs:DeleteCluster",
       "ecs:DeleteService",
       "ecs:DeregisterContainerInstance",
-      "ecs:ListContainerInstances",
-      "ecs:ListServices",
-      "ecs:ListTaskDefinitionFamilies",
-      "ecs:ListTaskDefinitions",
-      "ecs:ListTasks",
       "ecs:RegisterContainerInstance",
       "ecs:RunTask",
       "ecs:StartTask",
@@ -238,6 +223,12 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_ecr_ecs_elb_events
 
   statement {
     actions = [
+      "ecr:DescribeRegistry",
+      "ecr:DescribeRepositories",
+      "ecr:GetAuthorizationToken",
+      "ecr:ListTagsForResource",
+      "ecr:TagResource",
+      "ecr:UntagResource",
       "ecs:CreateCluster",
       "ecs:DeregisterTaskDefinition",
       "ecs:DescribeClusters",
@@ -246,6 +237,11 @@ data "aws_iam_policy_document" "provisiondomainmanager_policy_ecr_ecs_elb_events
       "ecs:DescribeTaskDefinition",
       "ecs:DescribeTasks",
       "ecs:ListClusters",
+      "ecs:ListContainerInstances",
+      "ecs:ListServices",
+      "ecs:ListTaskDefinitionFamilies",
+      "ecs:ListTaskDefinitions",
+      "ecs:ListTasks",
       "ecs:RegisterTaskDefinition",
       "elasticloadbalancing:DescribeListenerCertificates",
       "elasticloadbalancing:DescribeListeners",

--- a/provisiondomainmanager_policy_attachment.tf
+++ b/provisiondomainmanager_policy_attachment.tf
@@ -14,6 +14,11 @@ resource "aws_iam_role_policy_attachment" "provisiondomainmanager_policy_attachm
   role       = aws_iam_role.provisiondomainmanager_role.name
 }
 
+resource "aws_iam_role_policy_attachment" "provisiondomainmanager_policy_attachment_iam" {
+  policy_arn = aws_iam_policy.provisiondomainmanager_policy_iam.arn
+  role       = aws_iam_role.provisiondomainmanager_role.name
+}
+
 resource "aws_iam_role_policy_attachment" "provisiondomainmanager_policy_attachment_lambda_logs_rds" {
   policy_arn = aws_iam_policy.provisiondomainmanager_policy_lambda_logs_rds.arn
   role       = aws_iam_role.provisiondomainmanager_role.name

--- a/provisiondomainmanager_policy_attachment.tf
+++ b/provisiondomainmanager_policy_attachment.tf
@@ -4,8 +4,8 @@
 # account.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role_policy_attachment" "provisiondomainmanager_policy_attachment_acm_cognito_ec2" {
-  policy_arn = aws_iam_policy.provisiondomainmanager_policy_acm_cognito_ec2.arn
+resource "aws_iam_role_policy_attachment" "provisiondomainmanager_policy_attachment_acm_cloudwatch_cognito_ec2" {
+  policy_arn = aws_iam_policy.provisiondomainmanager_policy_acm_cloudwatch_cognito_ec2.arn
   role       = aws_iam_role.provisiondomainmanager_role.name
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,42 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "executedomainmanagerecs_role_description" {
+  type        = string
+  description = "The description to associate with the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager ECS in the User Services account."
+  default     = "Allows sufficient permissions needed for Domain Manager ECS execution in the User Services account."
+}
+
+variable "executedomainmanagerecs_role_name" {
+  type        = string
+  description = "The name to assign the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager ECS in the User Services account."
+  default     = "ExecuteDomainManagerECS"
+}
+
+variable "executedomainmanagerecstask_role_description" {
+  type        = string
+  description = "The description to associate with the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager ECS tasks in the User Services account."
+  default     = "Allows sufficient permissions needed for Domain Manager ECS task execution in the User Services account."
+}
+
+variable "executedomainmanagerecstask_role_name" {
+  type        = string
+  description = "The name to assign the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager ECS tasks in the User Services account."
+  default     = "ExecuteDomainManagerECSTask"
+}
+
+variable "executedomainmanagerlambda_role_description" {
+  type        = string
+  description = "The description to associate with the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager Lambdas in the User Services account."
+  default     = "Allows sufficient permissions needed for Domain Manager Lambda execution in the User Services account."
+}
+
+variable "executedomainmanagerlambda_role_name" {
+  type        = string
+  description = "The name to assign the IAM policy and role that allows sufficient AWS permissions to execute Domain Manager Lambdas in the User Services account."
+  default     = "ExecuteDomainManagerLambda"
+}
+
 variable "provisionaccount_role_description" {
   type        = string
   description = "The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the User Services account."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR does the following:
* Creates three new roles required by Domain Manager
  * ECS execution
  * ECS task execution
  * Lambda execution
* Adds additional permissions required by the `ProvisionDomainManager` role
 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Testing with @zenine07 yielded all of the changes in this PR, which will remain in Draft status until testing is completed.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

The changes were applied in Staging, then @zenine07 deployed Domain Manager.  When errors were encountered, the permissions were adjusted and testing was repeated.  This process will continue until @zenine07 confirms that Domain Manager has been successfully deployed.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
