### PR TITLE
Add SSM Session Manager role

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,21 @@ future changes by simply running `terraform apply
 | Name | Source | Version |
 |------|--------|---------|
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
+| run\_shell\_ssm\_document | gazoakley/session-manager-settings/aws | n/a |
 
 ## Resources ##
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.provisionssmdocument_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ssmsession_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.ssmsession_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.provisionssmdocument_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ssmsession_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.userservices](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.provisionssmdocument_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ssmsession_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs ##
 
@@ -103,6 +112,10 @@ future changes by simply running `terraform apply
 | aws\_region | The AWS region where the non-global resources for the User Services account are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the User Services account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the User Services account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the User Services account. | `string` | `"ProvisionAccount"` | no |
+| provisionssmdocument\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to provision the SSM Document resource in the User Services account. | `string` | `"Allows sufficient permissions to provision the SSM Document resource in the User Services account."` | no |
+| provisionssmdocument\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to provision the SSM Document resource in the User Services account. | `string` | `"ProvisionSSMDocument"` | no |
+| ssmsession\_role\_description | The description to associate with the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `"Allows creation of SSM SessionManager sessions to any EC2 instance in this account."` | no |
+| ssmsession\_role\_name | The name to assign the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account. | `string` | `"StartStopSSMSession"` | no |
 | tags | Tags to apply to all AWS resources provisioned. | `map(string)` | `{}` | no |
 | users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the User Services account. | `string` | n/a | yes |
 

--- a/assume_role_policy_doc.tf
+++ b/assume_role_policy_doc.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {

--- a/assume_role_policy_doc.tf
+++ b/assume_role_policy_doc.tf
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------------------
+# Create an IAM policy document that allows the users account to
+# assume this role.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.users_account_id,
+      ]
+    }
+  }
+}

--- a/provisionssmdocument_policy.tf
+++ b/provisionssmdocument_policy.tf
@@ -1,0 +1,27 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows all of the permissions necessary
+# to provision the SSM Document resource required in this account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "provisionssmdocument_policy_doc" {
+  statement {
+    actions = [
+      "ssm:AddTagsToResource",
+      "ssm:CreateDocument",
+      "ssm:DeleteDocument",
+      "ssm:DescribeDocument*",
+      "ssm:GetDocument",
+      "ssm:UpdateDocument*",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.userservices.account_id}:document/SSM-SessionManagerRunShell",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "provisionssmdocument_policy" {
+  description = var.provisionssmdocument_policy_description
+  name        = var.provisionssmdocument_policy_name
+  policy      = data.aws_iam_policy_document.provisionssmdocument_policy_doc.json
+}

--- a/provisionssmdocument_policy_attachment.tf
+++ b/provisionssmdocument_policy_attachment.tf
@@ -1,0 +1,9 @@
+# ------------------------------------------------------------------------------
+# Attach to the ProvisionAccount role the IAM policy that allows
+# provisioning of the SSM Document resource required in this account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "provisionssmdocument_policy_attachment" {
+  policy_arn = aws_iam_policy.provisionssmdocument_policy.arn
+  role       = module.provisionaccount.provisionaccount_role.name
+}

--- a/run_shell_ssm_document.tf
+++ b/run_shell_ssm_document.tf
@@ -1,0 +1,7 @@
+# ------------------------------------------------------------------------------
+# Create an SSM Document that allows creation of SSM SessionManager
+# sessions in this account.
+# ------------------------------------------------------------------------------
+module "run_shell_ssm_document" {
+  source = "gazoakley/session-manager-settings/aws"
+}

--- a/ssm_session_policy.tf
+++ b/ssm_session_policy.tf
@@ -1,0 +1,69 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows creation of SSM SessionManager
+# sessions to any EC2 instance in this account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "ssmsession_doc" {
+  # Allow the user to start a session
+  statement {
+    actions = [
+      "ssm:SendCommand",
+      "ssm:StartSession",
+    ]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.userservices.account_id}:instance/*",
+      "arn:aws:ssm:${var.aws_region}::document/AWS-StartPortForwardingSession",
+      "arn:aws:ssm:${var.aws_region}::document/AWS-StartSSHSession",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.userservices.account_id}:document/SSM-SessionManagerRunShell",
+    ]
+    condition {
+      test     = "BoolIfExists"
+      variable = "ssm:SessionDocumentAccessCheck"
+      values = [
+        true,
+      ]
+    }
+  }
+
+  # Allow the user to read documents
+  statement {
+    actions = [
+      "ssm:GetDocument",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}::document/AWS-StartPortForwardingSession",
+      "arn:aws:ssm:${var.aws_region}::document/AWS-StartSSHSession",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.userservices.account_id}:document/SSM-SessionManagerRunShell",
+    ]
+  }
+
+  # Allow the user to collect some information
+  statement {
+    actions = [
+      "ec2:DescribeInstances",
+      "ssm:DescribeInstanceInformation",
+      "ssm:DescribeInstanceProperties",
+      "ssm:DescribeSessions",
+      "ssm:GetConnectionStatus",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
+  # Allow the user to terminate his or her own sessions
+  statement {
+    actions = [
+      "ssm:TerminateSession",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.userservices.account_id}:session/&{aws:username}-*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ssmsession_policy" {
+  description = var.ssmsession_role_description
+  name        = var.ssmsession_role_name
+  policy      = data.aws_iam_policy_document.ssmsession_doc.json
+}

--- a/ssm_session_role.tf
+++ b/ssm_session_role.tf
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows creation of SSM SessionManager
+# sessions to any EC2 instance in this account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "ssmsession_role" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = var.ssmsession_role_description
+  name               = var.ssmsession_role_name
+}
+
+resource "aws_iam_role_policy_attachment" "ssmsession_policy_attachment" {
+  policy_arn = aws_iam_policy.ssmsession_policy.arn
+  role       = aws_iam_role.ssmsession_role.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,30 @@ variable "provisionaccount_role_name" {
   default     = "ProvisionAccount"
 }
 
+variable "provisionssmdocument_policy_description" {
+  type        = string
+  description = "The description to associate with the IAM policy that allows sufficient permissions to provision the SSM Document resource in the User Services account."
+  default     = "Allows sufficient permissions to provision the SSM Document resource in the User Services account."
+}
+
+variable "provisionssmdocument_policy_name" {
+  type        = string
+  description = "The name to assign the IAM policy that allows sufficient permissions to provision the SSM Document resource in the User Services account."
+  default     = "ProvisionSSMDocument"
+}
+
+variable "ssmsession_role_description" {
+  type        = string
+  description = "The description to associate with the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account."
+  default     = "Allows creation of SSM SessionManager sessions to any EC2 instance in this account."
+}
+
+variable "ssmsession_role_name" {
+  type        = string
+  description = "The name to assign the IAM role (and policy) that allows creation of SSM SessionManager sessions to any EC2 instance in this account."
+  default     = "StartStopSSMSession"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources provisioned."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a role that allows creation of SSM SessionManager sessions to any EC2 instance in the User Services account.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Now that someone is actually using the User Services account, we realized that this role was missing.  These changes parallel those made for Shared Services in https://github.com/cisagov/cool-accounts/pull/50.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied these changes in all deployed User Services workspaces and visually verified that the output looked as expected. 

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
