### PR TITLE
Support new COOL environment structure 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ be assumable from your IAM user that exists in the COOL users
 account. Therefore you can apply future changes using your IAM user
 credentials.
 
-To do this bootstrapping, follow these steps:
+To do this bootstrapping, follow these steps (for the purposes of these
+instructions, assume the environment is named "dev"):
 
 1. Comment out the `profile = "cool-userservices-provisionaccount"`
    line for the "default" provider in `providers.tf` and directly
@@ -40,23 +41,45 @@ To do this bootstrapping, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+of the bucket where Terraform state is stored for that environment.  This file
+is required to initialize the Terraform backend in each environment:
+
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE]
+    > When performing this step for additional environments (i.e. not your first
+    > environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
 1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with any optional variables
-   that you wish to override (see [Inputs](#inputs) below for
-   details):
+   `terraform workspace new dev`.
+1. Create a `dev.tfvars` file with all of the required variables (see
+  [Inputs](#inputs) below for details):
 
-   ```hcl
-   tags = {
-     Team        = "VM Fusion - Development"
-     Application = "COOL - User Services"
-     Workspace   = "production"
-   }
-   ```
+    ```hcl
+    terraform_state_bucket = "my-dev-terraform-state-bucket"
 
-1. Run the command `terraform init`.
-1. Run the command `terraform apply
-   -var-file=<workspace_name>.tfvars`.
+    tags = {
+      Application = "COOL - User Services"
+      Team        = "VM Fusion - Development"
+      Workspace   = "dev"
+    }
+    ```
+
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 1. Revert the changes you made to `providers.tf` in step 1.
 1. Create a new AWS profile called `cool-userservices-provisionaccount`
    in your local configuration that includes the `provisionaccount_role` ARN
@@ -69,12 +92,10 @@ To do this bootstrapping, follow these steps:
    source_profile = cool-user-base-profile
    ```
 
-1. Run the command `terraform apply
-    -var-file=<workspace_name>.tfvars`.
+1. Run the command `terraform apply -var-file=dev.tfvars`.
 
 At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+future changes by simply running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/backend.tf
+++ b/backend.tf
@@ -1,10 +1,14 @@
 terraform {
   backend "s3" {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts-userservices/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts-userservices/terraform.tfstate"
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes updates in support of the switchover from our legacy account/environment scheme (where staging and production accounts exist within the same AWS organization) to our new scheme (where they do not).

In this case, the primary change is the use of [partial backend configurations](https://developer.hashicorp.com/terraform/language/backend#partial-configuration).  I also updated the README to include updated bootstrapping instructions.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The goal of this PR is to get us closer to our modernized account scheme where there is no more co-mingling of staging and production accounts.  Doing that will result in cleaner code across all COOL-related repositories as well as improved separation of resources across all COOL environments. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this Terraform in dev-a, staging-a, and production environments and everything looks as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
